### PR TITLE
Simplify home page and improve navigation

### DIFF
--- a/Quiz.html
+++ b/Quiz.html
@@ -7,7 +7,10 @@
 <style>
   :root{ --bg:#0d0f10; --panel:#14181b; --ink:#e7f1f7; --muted:#9fb0bd; --accent:#1db954; --accent-2:#00a8ff; --radius:14px; }
   *{box-sizing:border-box}
-  body { background-color: var(--bg); color: var(--ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; margin: 0; display: grid; place-items: center; min-height: 100vh; padding: 20px; }
+  body { background-color: var(--bg); color: var(--ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; margin: 0; display: grid; place-items: center; min-height: 100vh; padding: 20px; opacity:0; animation:fadeIn .4s ease forwards; }
+  @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  a.home{position:fixed; top:20px; left:20px; text-decoration:none; color:var(--ink); font-weight:600;}
+  a.home:active{transform:translateY(1px);}
   #quiz-container { background: linear-gradient(180deg,#151a1d, #0f1214); border: 1px solid #24313a; padding: 22px; border-radius: var(--radius); width: 92%; max-width: 760px; text-align: center; box-shadow: 0 12px 40px rgba(0,0,0,0.35); }
   h1{ margin:6px 0 2px; font-size: 1.5rem; letter-spacing: 0.3px; }
   .kicker{color:var(--muted); font-size:.9rem; margin-bottom:18px}
@@ -27,6 +30,7 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 </head>
 <body>
+<a class="home" href="index.html" title="Home">← Home</a>
 
 <div id="quiz-container">
   <div class="kicker">Alpha · Demo</div>

--- a/Results.html
+++ b/Results.html
@@ -9,7 +9,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <style>
   :root{ --bg:#0f0f10; --panel:#151a1c; --ink:#eaf2f7; --muted:#9fb0bd; --radius:16px; --ring:#25323a; }
-  body { background-color: var(--bg); color: var(--ink); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin:0; }
+  body { background-color: var(--bg); color: var(--ink); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin:0; opacity:0; animation:fadeIn .4s ease forwards; }
+  @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
   main { display:flex; flex-direction:column; align-items:center; padding: 72px 20px 30px; }
   h1 { font-weight: 700; font-size: 2rem; margin-bottom: 10px; text-align: center; }
   .meta { color: var(--muted); margin-bottom: 22px; font-size: .95rem }
@@ -32,6 +33,7 @@
   button:hover { border-color:#2f4654; transform: translateY(-1px); }
   .muted{ color: var(--muted); font-size:.9rem }
   .topbar{ position:fixed; top:0; left:0; right:0; height:56px; display:flex; align-items:center; justify-content:space-between; padding:0 14px; backdrop-filter: blur(6px); background: rgba(15,16,17,.35); border-bottom:1px solid rgba(37,50,58,.35); z-index:20; }
+  .home{ text-decoration:none; color:var(--ink); font-weight:600; margin-right:12px; }
   .avatar{ width:36px; height:36px; border-radius:999px; background:linear-gradient(135deg,#00a8ff,#1db954); border:1px solid rgba(255,255,255,.15); display:grid; place-items:center; font-weight:800; font-size:.8rem; cursor:pointer; overflow:hidden }
   .avatar img{ width:100%; height:100%; object-fit:cover }
   .menu{ position:absolute; top:50px; right:10px; background:#0f1417; border:1px solid var(--ring); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.5); min-width:190px; display:none; }
@@ -59,7 +61,10 @@
 </head>
 <body>
   <div class="topbar">
-    <div class="muted" id="who"></div>
+    <div style="display:flex; align-items:center; gap:12px">
+      <a class="home" href="index.html">Home</a>
+      <div class="muted" id="who"></div>
+    </div>
     <div style="display:flex; align-items:center; gap:8px">
       <a class="muted" href="Profiles.html" style="text-decoration:none">Profiles</a>
       <div id="profileBtn" class="avatar" title="Profile"><span>PC</span></div>

--- a/index.html
+++ b/index.html
@@ -1,218 +1,71 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-<title>Power Chart · Home</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Power Chart</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <style>
-  :root{
-    --bg:#0b0d10; --panel:#12161a; --ink:#eaf2f7; --muted:#9fb0bd; --ring:#24323a;
-    --accent:#1db954; --accent2:#00a8ff; --radius:16px;
-    --tap:48px;
-  }
+  :root{ --bg:#0b0d10; --ink:#eaf2f7; --accent:#1db954; --accent2:#00a8ff; --ring:#24323a; }
   *{box-sizing:border-box}
-  html,body{height:100%}
   body{
-    margin:0; font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; color:var(--ink);
-    background: var(--bg);
-    -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+    margin:0; background:var(--bg); color:var(--ink);
+    font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+    display:flex; flex-direction:column; min-height:100vh;
+    opacity:0; animation:fadeIn .5s ease forwards;
   }
-
-  /* Header */
-  header{
-    position:sticky; top:0; z-index:30; backdrop-filter: blur(8px);
-    background: rgba(12,14,17,.55); border-bottom:1px solid rgba(37,50,58,.35);
-  }
-  .h-inner{ display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 14px; }
-  .brand{ display:flex; align-items:center; gap:10px; font-weight:800; letter-spacing:.3px }
-  .logo{ width:28px; height:28px; border-radius:8px; background:conic-gradient(from 90deg at 50% 50%, var(--accent2), var(--accent)); border:1px solid rgba(255,255,255,.15) }
-  .pfp{ width:36px; height:36px; border-radius:999px; border:1px solid rgba(255,255,255,.15); overflow:hidden; background:linear-gradient(135deg,#00a8ff,#1db954); display:grid; place-items:center; }
-  .pfp img{ width:100%; height:100%; object-fit:cover }
-  .sub{ color:var(--muted); font-size:.9rem }
-
-  /* Hero */
-  .hero{
-    display:grid; gap:12px; padding:16px 14px 6px;
-  }
-  .title{ font-size:clamp(1.6rem, 5vw, 2.6rem); line-height:1.1; margin:0 }
-  .kicker{ color:var(--muted); margin:0 }
-  .cta{ display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:8px }
-  .btn{
-    display:inline-flex; align-items:center; justify-content:center; gap:8px;
-    height:var(--tap); padding:0 14px; border-radius:12px; border:1px solid var(--ring); background:#10161a; color:var(--ink);
-    text-decoration:none; font-weight:700; font-size:1rem;
-  }
-  .btn.primary{ border:none; background:linear-gradient(90deg,var(--accent2),var(--accent)); color:#04130a; }
-  .btn.ghost{ background:transparent }
-  .btn:active{ transform: translateY(1px); }
-
-  /* Cards */
-  .section{ padding:10px 14px 90px; } /* leave space for bottom nav */
-  .panel{ background: linear-gradient(180deg, #151a1d, #0f1214); border:1px solid var(--ring); border-radius:var(--radius); padding:14px; box-shadow: 0 16px 50px rgba(0,0,0,.35); }
-  .grid{ display:grid; gap:10px; }
-  .card{ background:#0f1417; border:1px solid var(--ring); border-radius:14px; padding:12px; display:grid; gap:8px }
-  .card h3{ margin:0; font-size:1rem }
-  .muted{ color:var(--muted); font-size:.95rem }
-  .row{ display:flex; align-items:center; justify-content:space-between; gap:10px }
-  .pill{ font-size:.8rem; padding:2px 10px; border:1px solid #2b3a44; border-radius:999px; color:var(--muted) }
-
-  /* Bottom Nav (mobile-first) */
-  .nav-bottom{
-    position:fixed; left:0; right:0; bottom:0; z-index:40;
-    background:#0f1417; border-top:1px solid var(--ring);
-    padding: max(8px, env(safe-area-inset-bottom)) 8px  calc(env(safe-area-inset-bottom));
-  }
-  .tabs{ display:grid; grid-template-columns: repeat(4, 1fr); gap:8px; }
-  .tab{
-    height:var(--tap); border-radius:12px; border:1px solid var(--ring); background:#0c1114;
-    color:var(--ink); display:grid; place-items:center; text-decoration:none; font-weight:600; font-size:.95rem;
-  }
-  .tab:active{ transform: translateY(1px); }
-  .tab.primary{ background:linear-gradient(90deg,var(--accent2),var(--accent)); color:#04130a; border:none; }
-
-  /* Larger screens */
-  @media (min-width: 768px){
-    .hero{ grid-template-columns: 1.2fr 1fr; align-items:center; padding-top:24px }
-    .cta{ grid-template-columns: repeat(3, 1fr); }
-    .grid.cards{ grid-template-columns: repeat(2, 1fr); }
-    .section{ padding-bottom:24px }
-  }
-
-  /* Motion & touch tweaks */
-  @media (prefers-reduced-motion: reduce){
-    *{ animation:none !important; transition:none !important }
-  }
+  header{display:flex; justify-content:space-between; align-items:center; padding:12px 16px;}
+  .brand{font-weight:800; letter-spacing:.3px}
+  .pfp{width:36px; height:36px; border-radius:999px; border:1px solid rgba(255,255,255,.15); overflow:hidden; background:linear-gradient(135deg,#00a8ff,#1db954); display:grid; place-items:center;}
+  .pfp img{width:100%; height:100%; object-fit:cover}
+  main{flex:1; display:flex; align-items:center; justify-content:center;}
+  canvas{max-width:min(90vw,360px); max-height:360px;}
+  @keyframes fadeIn{from{opacity:0;} to{opacity:1;}}
 </style>
-
-  <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#1db954">
-  <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
+<link rel="manifest" href="manifest.webmanifest">
+<meta name="theme-color" content="#1db954">
+<link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 </head>
 <body>
-  <header>
-    <div class="h-inner">
-      <div class="brand">
-        <div class="logo"></div>
-        <div>
-          Power Chart
-          <div id="sub" class="sub">Loading profile…</div>
-        </div>
-      </div>
-      <a class="pfp" href="Profiles.html" title="Profiles"><span>PC</span></a>
-    </div>
-  </header>
-
-  <section class="hero">
-    <div>
-      <h1 class="title">Track your life like an RPG.</h1>
-      <p class="kicker">Big, thumb‑friendly buttons. Fast updates. All data stays on your device.</p>
-      <div class="cta">
-        <a class="btn primary" href="Quiz.html">Start Quiz</a>
-        <a class="btn" href="Results.html">My Chart</a>
-        <a class="btn" href="Data.html">Your Data</a>
-        <a class="btn ghost" href="Profiles.html">Profiles</a>
-      </div>
-    </div>
-    <div class="panel">
-      <div class="row">
-        <div>
-          <div class="muted">Active profile</div>
-          <div id="username" style="font-weight:800">Player One</div>
-        </div>
-        <span id="attrCount" class="pill">— attributes</span>
-      </div>
-      <div class="card" style="margin-top:8px">
-        <div class="row">
-          <strong>Last saved chart</strong>
-          <span id="lastSaved" class="muted">—</span>
-        </div>
-        <div class="row">
-          <span class="muted">Quick actions</span>
-          <div class="row" style="gap:6px">
-            <a class="btn" style="height:40px;padding:0 10px" href="Quiz.html">Quiz</a>
-            <a class="btn" style="height:40px;padding:0 10px" href="Data.html">Update Data</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="grid cards">
-      <div class="card">
-        <h3>Color & Opacity</h3>
-        <p class="muted">Customize your chart appearance. Saved per profile.</p>
-        <a class="btn" href="Results.html">Open Results</a>
-      </div>
-      <div class="card">
-        <h3>Attributes</h3>
-        <p class="muted">Toggle which stats you want to track (Career, Strength, etc.).</p>
-        <a class="btn" href="Profiles.html">Manage in Profiles</a>
-      </div>
-    </div>
-  </section>
-
-  <nav class="nav-bottom">
-    <div class="tabs">
-      <a class="tab primary" href="Results.html">Results</a>
-      <a class="tab" href="Quiz.html">Quiz</a>
-      <a class="tab" href="Data.html">Data</a>
-      <a class="tab" href="Profiles.html">Profiles</a>
-    </div>
-  </nav>
-
-  <!-- minimal profile reader -->
-  
+<header>
+  <div class="brand">Power Chart</div>
+  <a class="pfp" href="Profiles.html" title="Profiles"><span>PC</span></a>
+</header>
+<main>
+  <canvas id="placeholderChart"></canvas>
+</main>
 <script>
-/* Minimal profile helper (read-only here) */
 const PC_MIN = (function(){
   const KEY = "powerChart.profiles";
   function load(){ try{ return JSON.parse(localStorage.getItem(KEY) || "{}"); }catch(e){ return {}; } }
   function getActive(){
     const s = load();
     if (!s.activeId || !s.byId || !s.byId[s.activeId]) {
-      return { id:null, username:"Player One", pfp:null, enabledAttrs:["Intellect","Religion","Strength","Endurance","Social Life","Mental Health","Career"] };
+      return { id:null, username:"Player One", pfp:null };
     }
     return { id:s.activeId, ...s.byId[s.activeId] };
   }
   return { getActive };
 })();
-</script>
-
-
-<script>
 (function init(){
   const p = PC_MIN.getActive();
-  const sub = document.getElementById('sub');
-  const nameEl = document.getElementById('username');
-  const attrCountEl = document.getElementById('attrCount');
   const pfp = document.querySelector('.pfp');
-
-  sub.textContent = (p.enabledAttrs ? p.enabledAttrs.length : 7) + " attributes enabled";
-  nameEl.textContent = p.username || "Player One";
-  attrCountEl.textContent = (p.enabledAttrs ? p.enabledAttrs.length : 7) + " attributes";
   if (p.pfp){ pfp.innerHTML = '<img alt="pfp">'; pfp.querySelector('img').src = p.pfp; }
-
-  const latest = JSON.parse(localStorage.getItem("powerChart.latest."+ (p.id || "")) || "null") ||
-                 JSON.parse(localStorage.getItem("powerChart.latest") || "null"); // fallback first run
-  if (latest && latest.timestamp){
-    const dt = new Date(latest.timestamp);
-    const nice = dt.toLocaleString(undefined, {year:"numeric", month:"short", day:"2-digit", hour:"2-digit", minute:"2-digit"});
-    document.getElementById("lastSaved").textContent = nice;
-  } else {
-    document.getElementById("lastSaved").textContent = "none yet";
-  }
 })();
 </script>
-
-  <script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', function() {
-      navigator.serviceWorker.register('service-worker.js').catch(console.error);
-    });
-  }
-  </script>
+<script>
+const labels=["Intellect","Religion","Strength","Endurance","Social Life","Mental","Career"];
+const data=labels.map(()=>50);
+const ctx=document.getElementById('placeholderChart');
+new Chart(ctx,{type:'radar',data:{labels,datasets:[{data,backgroundColor:'rgba(29,185,84,0.25)',borderColor:'rgba(29,185,84,1)',borderWidth:2,pointRadius:0}]},options:{plugins:{legend:{display:false}},scales:{r:{ticks:{display:false,beginAtZero:true},angleLines:{color:'rgba(255,255,255,.1)'},grid:{color:'rgba(255,255,255,.1)'},pointLabels:{color:'rgba(234,242,247,.6)'}}}}});
+</script>
+<script>
+if('serviceWorker' in navigator){
+  window.addEventListener('load',()=>{
+    navigator.serviceWorker.register('service-worker.js').catch(console.error);
+  });
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Redesign landing page into a minimalist canvas with a placeholder radar chart and profile button
- Add animated fade-ins and a back-to-home link in quiz for smoother navigation
- Include home link on results page for quick return to landing screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7bbf2ec08332befa99be9752cf51